### PR TITLE
New s6 nrt ipynb

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 **/.DS_Store
 **/regrid*.nc
 **/ogc_temp.nc
+notebooks/resources/nrt
+notebooks/resources/cyclepass

--- a/notebooks/Access_Sentinel6_NRT.ipynb
+++ b/notebooks/Access_Sentinel6_NRT.ipynb
@@ -23,7 +23,7 @@
     "\n",
     "## Before you start\n",
     "\n",
-    "Before you beginning this tutorial, make sure you have an Earthdata account: [https://uat.urs.earthdata.nasa.gov](https://uat.urs.earthdata.nasa.gov). \n",
+    "Before you beginning this tutorial, make sure you have an Earthdata account: [https://urs.earthdata.nasa.gov](https://urs.earthdata.nasa.gov) for the operations envionrment (most common) or [https://uat.urs.earthdata.nasa.gov](https://uat.urs.earthdata.nasa.gov) for the UAT environment.\n",
     "\n",
     "Accounts are free to create and take just a moment to set up.\n",
     "\n",
@@ -50,11 +50,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 1,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-08-10T20:09:57.722484Z",
-     "start_time": "2020-08-10T20:09:57.717843Z"
+     "end_time": "2020-08-11T17:34:07.928944Z",
+     "start_time": "2020-08-11T17:34:07.913616Z"
     }
    },
    "outputs": [],
@@ -97,11 +97,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 2,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-08-10T20:09:57.729917Z",
-     "start_time": "2020-08-10T20:09:57.725464Z"
+     "end_time": "2020-08-11T17:34:08.212835Z",
+     "start_time": "2020-08-11T17:34:08.203168Z"
     }
    },
    "outputs": [],
@@ -131,11 +131,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 3,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-08-10T20:09:57.757568Z",
-     "start_time": "2020-08-10T20:09:57.754922Z"
+     "end_time": "2020-08-11T17:34:08.712987Z",
+     "start_time": "2020-08-11T17:34:08.710091Z"
     },
     "tags": [
      "parameters"
@@ -173,11 +173,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 4,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-08-10T20:09:57.786262Z",
-     "start_time": "2020-08-10T20:09:57.783722Z"
+     "end_time": "2020-08-11T17:34:09.343381Z",
+     "start_time": "2020-08-11T17:34:09.340343Z"
     }
    },
    "outputs": [],
@@ -199,21 +199,21 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 5,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-08-10T20:09:57.819194Z",
-     "start_time": "2020-08-10T20:09:57.811721Z"
+     "end_time": "2020-08-11T17:34:10.190280Z",
+     "start_time": "2020-08-11T17:34:10.180693Z"
     }
    },
    "outputs": [
     {
      "data": {
       "text/plain": [
-       "'2020-08-10T19:49:57Z'"
+       "'2020-08-11T17:14:10Z'"
       ]
      },
-     "execution_count": 7,
+     "execution_count": 5,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -232,11 +232,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 6,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-08-10T20:09:57.846839Z",
-     "start_time": "2020-08-10T20:09:57.842427Z"
+     "end_time": "2020-08-11T17:34:13.477396Z",
+     "start_time": "2020-08-11T17:34:13.472753Z"
     }
    },
    "outputs": [
@@ -244,7 +244,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "NOTE: .update found in the data directory. (The last run was at 2020-08-07T19:48:49Z.)\n"
+      "NOTE: .update found in the data directory. (The last run was at 2020-08-11T17:29:35Z.)\n"
      ]
     }
    ],
@@ -278,11 +278,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 7,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-08-10T20:09:57.876967Z",
-     "start_time": "2020-08-10T20:09:57.873137Z"
+     "end_time": "2020-08-11T17:34:15.176292Z",
+     "start_time": "2020-08-11T17:34:15.171348Z"
     }
    },
    "outputs": [
@@ -293,11 +293,11 @@
        " 'page_size': 2000,\n",
        " 'sort_key': '-start_date',\n",
        " 'collection_concept_id': 'C1234724470-POCLOUD',\n",
-       " 'created_at': '2020-08-07T19:48:49Z',\n",
+       " 'created_at': '2020-08-11T17:29:35Z',\n",
        " 'bounding_box': '-146.5,57.5,-146,58'}"
       ]
      },
-     "execution_count": 9,
+     "execution_count": 7,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -325,11 +325,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 10,
+   "execution_count": 8,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-08-10T20:09:57.906733Z",
-     "start_time": "2020-08-10T20:09:57.904028Z"
+     "end_time": "2020-08-11T17:34:16.816986Z",
+     "start_time": "2020-08-11T17:34:16.813631Z"
     }
    },
    "outputs": [
@@ -337,7 +337,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "https://cmr.uat.earthdata.nasa.gov/search/granules.umm_json?scroll=true&page_size=2000&sort_key=-start_date&collection_concept_id=C1234724470-POCLOUD&created_at=2020-08-07T19%3A48%3A49Z&bounding_box=-146.5%2C57.5%2C-146%2C58\n"
+      "https://cmr.uat.earthdata.nasa.gov/search/granules.umm_json?scroll=true&page_size=2000&sort_key=-start_date&collection_concept_id=C1234724470-POCLOUD&created_at=2020-08-11T17%3A29%3A35Z&bounding_box=-146.5%2C57.5%2C-146%2C58\n"
      ]
     }
    ],
@@ -356,11 +356,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
+   "execution_count": 9,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-08-10T20:09:59.930841Z",
-     "start_time": "2020-08-10T20:09:57.934546Z"
+     "end_time": "2020-08-11T17:34:18.168810Z",
+     "start_time": "2020-08-11T17:34:17.709156Z"
     }
    },
    "outputs": [
@@ -368,7 +368,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "62 new granules ingested for 'C1234724470-POCLOUD' since '2020-08-10T20:09:57Z'.\n"
+      "0 new granules ingested for 'C1234724470-POCLOUD' since '2020-08-11T17:34:17Z'.\n"
      ]
     }
    ],
@@ -390,102 +390,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 12,
+   "execution_count": 10,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-08-10T20:09:59.936563Z",
-     "start_time": "2020-08-10T20:09:59.933224Z"
+     "end_time": "2020-08-11T17:34:19.667755Z",
+     "start_time": "2020-08-11T17:34:19.665059Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "{\n",
-      "  \"meta\": {\n",
-      "    \"concept-type\": \"granule\",\n",
-      "    \"concept-id\": \"G1236893972-POCLOUD\",\n",
-      "    \"revision-id\": 1,\n",
-      "    \"native-id\": \"20200810110501-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0\",\n",
-      "    \"provider-id\": \"POCLOUD\",\n",
-      "    \"format\": \"application/vnd.nasa.cmr.umm+json\",\n",
-      "    \"revision-date\": \"2020-08-10T14:44:56Z\"\n",
-      "  },\n",
-      "  \"umm\": {\n",
-      "    \"RelatedUrls\": [\n",
-      "      {\n",
-      "        \"URL\": \"https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200810110501-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\",\n",
-      "        \"Type\": \"GET DATA\",\n",
-      "        \"Description\": \"The base directory location for the granule.\"\n",
-      "      },\n",
-      "      {\n",
-      "        \"URL\": \"https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-public/MODIS_A-JPL-L2P-v2019.0/20200810110501-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.cmr.json\",\n",
-      "        \"Type\": \"EXTENDED METADATA\",\n",
-      "        \"Description\": \"File to download\"\n",
-      "      },\n",
-      "      {\n",
-      "        \"URL\": \"https://archive.podaac.uat.earthdata.nasa.gov/s3credentials\",\n",
-      "        \"Type\": \"VIEW RELATED INFORMATION\",\n",
-      "        \"Description\": \"api endpoint to retrieve temporary credentials valid for same-region direct s3 access\"\n",
-      "      }\n",
-      "    ],\n",
-      "    \"SpatialExtent\": {\n",
-      "      \"HorizontalSpatialDomain\": {\n",
-      "        \"Geometry\": {\n",
-      "          \"BoundingRectangles\": [\n",
-      "            {\n",
-      "              \"WestBoundingCoordinate\": -150.336,\n",
-      "              \"EastBoundingCoordinate\": -110.883,\n",
-      "              \"NorthBoundingCoordinate\": 60.293,\n",
-      "              \"SouthBoundingCoordinate\": 38.478\n",
-      "            }\n",
-      "          ]\n",
-      "        }\n",
-      "      }\n",
-      "    },\n",
-      "    \"ProviderDates\": [\n",
-      "      {\n",
-      "        \"Date\": \"2020-08-10T14:44:40.727Z\",\n",
-      "        \"Type\": \"Insert\"\n",
-      "      },\n",
-      "      {\n",
-      "        \"Date\": \"2020-08-10T14:44:40.728Z\",\n",
-      "        \"Type\": \"Update\"\n",
-      "      }\n",
-      "    ],\n",
-      "    \"CollectionReference\": {\n",
-      "      \"ShortName\": \"MODIS_A-JPL-L2P-v2019.0\",\n",
-      "      \"Version\": \"2019.0\"\n",
-      "    },\n",
-      "    \"DataGranule\": {\n",
-      "      \"DayNightFlag\": \"Unspecified\",\n",
-      "      \"ProductionDateTime\": \"2020-08-10T14:42:14.000Z\",\n",
-      "      \"ArchiveAndDistributionInformation\": [\n",
-      "        {\n",
-      "          \"Name\": \"Not provided\",\n",
-      "          \"Size\": 22.679931640625,\n",
-      "          \"SizeUnit\": \"MB\"\n",
-      "        }\n",
-      "      ]\n",
-      "    },\n",
-      "    \"TemporalExtent\": {\n",
-      "      \"RangeDateTime\": {\n",
-      "        \"BeginningDateTime\": \"2020-08-10T11:05:01.000Z\",\n",
-      "        \"EndingDateTime\": \"2020-08-10T11:09:58.000Z\"\n",
-      "      }\n",
-      "    },\n",
-      "    \"GranuleUR\": \"20200810110501-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0\",\n",
-      "    \"MetadataSpecification\": {\n",
-      "      \"URL\": \"https://cdn.earthdata.nasa.gov/umm/granule/v1.6.1\",\n",
-      "      \"Name\": \"UMM-G\",\n",
-      "      \"Version\": \"1.6.1\"\n",
-      "    }\n",
-      "  }\n",
-      "}\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "if len(results['items'])>0:\n",
     "    print(dumps(results['items'][0], indent=2))"
@@ -495,18 +407,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "The link for http access denoted by `\"Type\": \"GET DATA\"` in the list of `RelatedUrls`.\n",
+    "The link for http access can be retrieved from each granule record's `RelatedUrls` field. The download link is identified by `\"Type\": \"GET DATA\"` .\n",
     "\n",
-    "Grab the download URL, but do it in a way that'll work for search results returning any number of granule records:"
+    "Select the download URL for each of the granule records:"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 13,
+   "execution_count": 11,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-08-10T20:09:59.943535Z",
-     "start_time": "2020-08-10T20:09:59.939038Z"
+     "end_time": "2020-08-11T17:34:20.408069Z",
+     "start_time": "2020-08-11T17:34:20.404068Z"
     },
     "scrolled": false
    },
@@ -514,77 +426,16 @@
     {
      "data": {
       "text/plain": [
-       "['https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200810110501-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200810110001-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200810110001-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809231501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809213501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809133501-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809133501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809120001-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809115501-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809115501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808223001-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808205501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808143001-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808143001-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808125500-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808111500-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808111500-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200807232500-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200807215000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200807214500-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200807201000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170529231511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170529213511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170506231011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170506230511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170506213011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170502233510-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170502233010-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170403222511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170403204511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170403191011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170401224011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170401223511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170401210011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170315233510-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170315233010-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170315215510-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170223222011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170223221511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170223204011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217225511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217211511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217194011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217194011-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217145510-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217132010-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217131510-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217114010-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211233510-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211233510-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211233010-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211215511-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211215511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211215000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211201511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211135511-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211121511-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211103511-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170207222011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170207222011-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170207221511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
-       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170207204011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc']"
+       "[]"
       ]
      },
-     "execution_count": 13,
+     "execution_count": 11,
      "metadata": {},
      "output_type": "execute_result"
     }
    ],
    "source": [
-    "downloads = [r['umm']['RelatedUrls'][0]['URL'] for r in results['items']]\n",
+    "downloads = [[u['URL'] for u in r['umm']['RelatedUrls'] if u['Type']==\"GET DATA\"][0] for r in results['items']]\n",
     "downloads"
    ]
   },
@@ -602,90 +453,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 14,
+   "execution_count": 12,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-08-10T20:18:12.840943Z",
-     "start_time": "2020-08-10T20:09:59.945391Z"
+     "end_time": "2020-08-11T17:34:21.088917Z",
+     "start_time": "2020-08-11T17:34:21.085442Z"
     },
     "scrolled": false
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[2020-08-10 16:10:13.365572] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200810110501-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:10:18.975776] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200810110001-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:10:31.304843] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200810110001-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:10:53.600871] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809231501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:10:57.873046] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809213501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:11:08.034197] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809133501-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:11:13.276993] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809133501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:11:23.881797] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809120001-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:11:28.736203] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809115501-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:11:39.485791] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809115501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:11:54.069467] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808223001-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:12:04.598151] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808205501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:12:09.996264] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808143001-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:12:19.912755] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808143001-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:12:24.800578] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808125500-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:12:34.344117] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808111500-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:12:38.639197] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808111500-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:12:48.810996] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200807232500-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:12:53.882255] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200807215000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:13:00.002196] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200807214500-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:13:04.365358] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200807201000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:13:16.629838] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170529231511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:13:21.321980] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170529213511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:13:31.527094] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170506231011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:13:36.265612] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170506230511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:13:41.916333] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170506213011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:13:46.281718] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170502233510-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:13:55.152083] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170502233010-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:13:59.405846] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170403222511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:14:05.009704] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170403204511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:14:10.770693] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170403191011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:14:15.003264] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170401224011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:14:25.534173] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170401223511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:14:29.895261] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170401210011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:14:41.572266] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170315233510-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:14:46.289246] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170315233010-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:14:52.116066] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170315215510-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:14:57.738353] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170223222011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:15:13.384346] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170223221511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:15:23.422584] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170223204011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:15:27.931576] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217225511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n"
-     ]
-    },
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "[2020-08-10 16:15:37.323237] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217211511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:15:42.016601] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217194011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:15:53.458549] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217194011-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:16:06.300466] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217145510-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:16:20.545108] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217132010-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:16:24.906572] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217131510-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:16:30.120924] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217114010-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:16:35.055420] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211233510-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:16:46.486338] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211233510-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:16:51.774150] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211233010-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:16:59.050474] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211215511-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:17:05.286920] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211215511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:17:17.746501] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211215000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:17:27.765510] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211201511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:17:32.327060] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211135511-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:17:40.928408] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211121511-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:17:45.611211] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211103511-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:17:56.680623] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170207222011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:18:01.981545] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170207222011-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:18:08.549494] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170207221511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
-      "[2020-08-10 16:18:12.839515] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170207204011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "for f in downloads:\n",
     "    try:\n",
@@ -706,11 +482,11 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 15,
+   "execution_count": 13,
    "metadata": {
     "ExecuteTime": {
-     "end_time": "2020-08-10T20:18:12.846894Z",
-     "start_time": "2020-08-10T20:18:12.842383Z"
+     "end_time": "2020-08-11T17:34:22.362167Z",
+     "start_time": "2020-08-11T17:34:22.359386Z"
     }
    },
    "outputs": [],

--- a/notebooks/Access_Sentinel6_NRT.ipynb
+++ b/notebooks/Access_Sentinel6_NRT.ipynb
@@ -1,0 +1,770 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "toc": true
+   },
+   "source": [
+    "<h1>Table of Contents<span class=\"tocSkip\"></span></h1>\n",
+    "<div class=\"toc\"><ul class=\"toc-item\"><li><span><a href=\"#Before-you-start\" data-toc-modified-id=\"Before-you-start-1\"><span class=\"toc-item-num\">1&nbsp;&nbsp;</span>Before you start</a></span></li><li><span><a href=\"#Authentication-setup\" data-toc-modified-id=\"Authentication-setup-2\"><span class=\"toc-item-num\">2&nbsp;&nbsp;</span>Authentication setup</a></span></li><li><span><a href=\"#Hands-off-workflow\" data-toc-modified-id=\"Hands-off-workflow-3\"><span class=\"toc-item-num\">3&nbsp;&nbsp;</span>Hands-off workflow</a></span></li></ul></div>"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Access Sentinel-6 NRT Data\n",
+    "\n",
+    "This notebook shows a simple way to maintain a local time series of Sentinel-6 NRT data using the [CMR Search API](https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html). It downloads granules the ingested since the previous run to a designated data folder and overwrites a hidden file inside with the timestamp of the CMR Search request on success.\n",
+    "\n",
+    "> **User note:**\n",
+    ">  The notebook actually points to a MODIS SST collection for now ([https://doi.org/10.5067/GHMDA-2PJ19](https://doi.org/10.5067/GHMDA-2PJ19)). It will work just the same for Sentinel-6.\n",
+    "\n",
+    "## Before you start\n",
+    "\n",
+    "Before you beginning this tutorial, make sure you have an Earthdata account: [https://uat.urs.earthdata.nasa.gov](https://uat.urs.earthdata.nasa.gov). \n",
+    "\n",
+    "Accounts are free to create and take just a moment to set up.\n",
+    "\n",
+    "## Authentication setup\n",
+    "\n",
+    "We need some boilerplate up front to log in to Earthdata Login.  The function below will allow Python\n",
+    "scripts to log into any Earthdata Login application programmatically.  To avoid being prompted for\n",
+    "credentials every time you run and also allow clients such as curl to log in, you can add the following\n",
+    "to a `.netrc` (`_netrc` on Windows) file in your home directory:\n",
+    "\n",
+    "```\n",
+    "machine uat.urs.earthdata.nasa.gov\n",
+    "    login <your username>\n",
+    "    password <your password>\n",
+    "```\n",
+    "\n",
+    "Make sure that this file is only readable by the current user or you will receive an error stating\n",
+    "\"netrc access too permissive.\"\n",
+    "\n",
+    "`$ chmod 0600 ~/.netrc` \n",
+    "\n",
+    "*You'll need to authenticate using the netrc method when running from command line with [`papermill`](https://papermill.readthedocs.io/en/latest/). You can log in manually by executing the cell below when running in the notebook client in your browser.*"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-08-10T20:09:57.722484Z",
+     "start_time": "2020-08-10T20:09:57.717843Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from urllib import request\n",
+    "from http.cookiejar import CookieJar\n",
+    "import getpass\n",
+    "import netrc\n",
+    "\n",
+    "\n",
+    "def setup_earthdata_login_auth(endpoint):\n",
+    "    \"\"\"\n",
+    "    Set up the request library so that it authenticates against the given Earthdata Login\n",
+    "    endpoint and is able to track cookies between requests.  This looks in the .netrc file \n",
+    "    first and if no credentials are found, it prompts for them.\n",
+    "\n",
+    "    Valid endpoints include:\n",
+    "        uat.urs.earthdata.nasa.gov - Earthdata Login UAT (Harmony's current default)\n",
+    "        urs.earthdata.nasa.gov - Earthdata Login production\n",
+    "    \"\"\"\n",
+    "    try:\n",
+    "        username, _, password = netrc.netrc().authenticators(endpoint)\n",
+    "    except (FileNotFoundError, TypeError):\n",
+    "        # FileNotFound = There's no .netrc file\n",
+    "        # TypeError = The endpoint isn't in the netrc file, causing the above to try unpacking None\n",
+    "        print('Please provide your Earthdata Login credentials to allow data access')\n",
+    "        print('Your credentials will only be passed to %s and will not be exposed in Jupyter' % (endpoint))\n",
+    "        username = input('Username:')\n",
+    "        password = getpass.getpass()\n",
+    "\n",
+    "    manager = request.HTTPPasswordMgrWithDefaultRealm()\n",
+    "    manager.add_password(None, endpoint, username, password)\n",
+    "    auth = request.HTTPBasicAuthHandler(manager)\n",
+    "\n",
+    "    jar = CookieJar()\n",
+    "    processor = request.HTTPCookieProcessor(jar)\n",
+    "    opener = request.build_opener(auth, processor)\n",
+    "    request.install_opener(opener)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-08-10T20:09:57.729917Z",
+     "start_time": "2020-08-10T20:09:57.725464Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "setup_earthdata_login_auth('uat.urs.earthdata.nasa.gov')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Hands-off workflow\n",
+    "\n",
+    "This workflow/notebook can be run routinely to maintain a time series of NRT data, downloading new granules as they become available in CMR. \n",
+    "\n",
+    "The notebook writes/overwrites a file `.update` to the target data directory with each successful run. The file tracks to date and time of the most recent update to the time series of NRT granules using a timestamp in the format `yyyy-mm-ddThh:mm:ssZ`. \n",
+    "\n",
+    "The timestamp matches the value used for the [`created_at`](https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#g-created-at) parameter in the last successful run. This parameter finds the granules created within a range of datetimes. This workflow leverages the `created_at` parameter to search backwards in time for new granules ingested between the time of our timestamp and now.\n",
+    "\n",
+    "The variables in the cell below determine the workflow behavior on its initial run:\n",
+    "\n",
+    "* `mins`: Initialize a new local time series by starting with the granules ingested since ___ minutes ago. \n",
+    "* `cmr`: The domain of the target CMR instance, either `cmr.earthdata.nasa.gov` or `cmr.uat.earthdata.nasa.gov`.\n",
+    "* `ccid`: The unique CMR `concept-id` of the desired collection.\n",
+    "* `data`: The path to a local directory in which to download/maintain a copy of the NRT granule time series."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-08-10T20:09:57.757568Z",
+     "start_time": "2020-08-10T20:09:57.754922Z"
+    },
+    "tags": [
+     "parameters"
+    ]
+   },
+   "outputs": [],
+   "source": [
+    "#\n",
+    "# This cell accepts parameters from command line with papermill: \n",
+    "#  https://papermill.readthedocs.io\n",
+    "#\n",
+    "# These variables should be set before the first run, then they \n",
+    "#  should be left alone. All subsequent runs expect the values \n",
+    "#  for cmr, ccid, data to be unchanged. The mins value has no \n",
+    "#  impact on subsequent runs.\n",
+    "#\n",
+    "\n",
+    "mins = 20\n",
+    "\n",
+    "cmr = \"cmr.uat.earthdata.nasa.gov\"\n",
+    "\n",
+    "ccid = \"C1234724470-POCLOUD\"\n",
+    "\n",
+    "data = \"resources/nrt\""
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The variable `data` is pointed at a nearby folder [`resources/nrt`](resources/nrt/) by default. **You should change `data` to a suitable download path on your file system.** An unlucky sequence of git commands could disappear that folder and its downloads if your not careful. Just change it.\n",
+    "\n",
+    "The Python imports relevant to the workflow"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-08-10T20:09:57.786262Z",
+     "start_time": "2020-08-10T20:09:57.783722Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from os import makedirs\n",
+    "from os.path import isdir, basename\n",
+    "from urllib.parse import urlencode\n",
+    "from urllib.request import urlopen, urlretrieve\n",
+    "from datetime import datetime, timedelta\n",
+    "from json import dumps, loads"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**The search retrieves granules ingested during the last `n` minutes.** A file in your local data dir  file that tracks updates to your data directory, if one file exists. The CMR Search falls back on the ten minute window if not."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-08-10T20:09:57.819194Z",
+     "start_time": "2020-08-10T20:09:57.811721Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "'2020-08-10T19:49:57Z'"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "timestamp = (datetime.utcnow()-timedelta(minutes=mins)).strftime(\"%Y-%m-%dT%H:%M:%SZ\")\n",
+    "timestamp"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "This cell will replace the timestamp above with the one read from the `.update` file in the data directory, if it exists."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-08-10T20:09:57.846839Z",
+     "start_time": "2020-08-10T20:09:57.842427Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "NOTE: .update found in the data directory. (The last run was at 2020-08-07T19:48:49Z.)\n"
+     ]
+    }
+   ],
+   "source": [
+    "if not isdir(data):\n",
+    "    print(f\"NOTE: Making new data directory at '{data}'. (This is the first run.)\")\n",
+    "    makedirs(data)\n",
+    "else:\n",
+    "    try:\n",
+    "        with open(f\"{data}/.update\", \"r\") as f:\n",
+    "            timestamp = f.read()\n",
+    "    except FileNotFoundError:\n",
+    "        print(\"WARN: No .update in the data directory. (Is this the first run?)\")\n",
+    "    else:\n",
+    "        print(f\"NOTE: .update found in the data directory. (The last run was at {timestamp}.)\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "There are several ways to query for CMR updates that occured during a given timeframe. Read on in the CMR Search documentation:\n",
+    "\n",
+    "* https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#c-with-new-granules (Collections)\n",
+    "* https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#c-with-revised-granules (Collections)\n",
+    "* https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#g-production-date (Granules)\n",
+    "* https://cmr.earthdata.nasa.gov/search/site/docs/search/api.html#g-created-at (Granules)\n",
+    "\n",
+    "The `created_at` parameter works for our purposes. It's a granule search parameter that returns the records ingested since the input timestamp."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-08-10T20:09:57.876967Z",
+     "start_time": "2020-08-10T20:09:57.873137Z"
+    }
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "{'scroll': 'true',\n",
+       " 'page_size': 2000,\n",
+       " 'sort_key': '-start_date',\n",
+       " 'collection_concept_id': 'C1234724470-POCLOUD',\n",
+       " 'created_at': '2020-08-07T19:48:49Z',\n",
+       " 'bounding_box': '-146.5,57.5,-146,58'}"
+      ]
+     },
+     "execution_count": 9,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "params = {\n",
+    "    'scroll': \"true\",\n",
+    "    'page_size': 2000,\n",
+    "    'sort_key': \"-start_date\",\n",
+    "    'collection_concept_id': ccid, \n",
+    "    'created_at': timestamp,\n",
+    "    # Limit results to coverage for .5deg bbox in Gulf of Alaska:\n",
+    "    'bounding_box': \"-146.5,57.5,-146,58\",\n",
+    "}\n",
+    "\n",
+    "params"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get the query parameters as a string and then the complete search url:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-08-10T20:09:57.906733Z",
+     "start_time": "2020-08-10T20:09:57.904028Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "https://cmr.uat.earthdata.nasa.gov/search/granules.umm_json?scroll=true&page_size=2000&sort_key=-start_date&collection_concept_id=C1234724470-POCLOUD&created_at=2020-08-07T19%3A48%3A49Z&bounding_box=-146.5%2C57.5%2C-146%2C58\n"
+     ]
+    }
+   ],
+   "source": [
+    "query = urlencode(params)\n",
+    "url = f\"https://{cmr}/search/granules.umm_json?{query}\"\n",
+    "print(url)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Get a new timestamp that represents the UTC time of the search. Then download the records in `umm_json` format for granules that match our search parameters:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-08-10T20:09:59.930841Z",
+     "start_time": "2020-08-10T20:09:57.934546Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "62 new granules ingested for 'C1234724470-POCLOUD' since '2020-08-10T20:09:57Z'.\n"
+     ]
+    }
+   ],
+   "source": [
+    "timestamp = datetime.utcnow().strftime(\"%Y-%m-%dT%H:%M:%SZ\")\n",
+    "\n",
+    "with urlopen(url) as f:\n",
+    "    results = loads(f.read().decode())\n",
+    "\n",
+    "print(f\"{results['hits']} new granules ingested for '{ccid}' since '{timestamp}'.\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Neatly print the first granule record (if one was returned):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-08-10T20:09:59.936563Z",
+     "start_time": "2020-08-10T20:09:59.933224Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "{\n",
+      "  \"meta\": {\n",
+      "    \"concept-type\": \"granule\",\n",
+      "    \"concept-id\": \"G1236893972-POCLOUD\",\n",
+      "    \"revision-id\": 1,\n",
+      "    \"native-id\": \"20200810110501-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0\",\n",
+      "    \"provider-id\": \"POCLOUD\",\n",
+      "    \"format\": \"application/vnd.nasa.cmr.umm+json\",\n",
+      "    \"revision-date\": \"2020-08-10T14:44:56Z\"\n",
+      "  },\n",
+      "  \"umm\": {\n",
+      "    \"RelatedUrls\": [\n",
+      "      {\n",
+      "        \"URL\": \"https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200810110501-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\",\n",
+      "        \"Type\": \"GET DATA\",\n",
+      "        \"Description\": \"The base directory location for the granule.\"\n",
+      "      },\n",
+      "      {\n",
+      "        \"URL\": \"https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-public/MODIS_A-JPL-L2P-v2019.0/20200810110501-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.cmr.json\",\n",
+      "        \"Type\": \"EXTENDED METADATA\",\n",
+      "        \"Description\": \"File to download\"\n",
+      "      },\n",
+      "      {\n",
+      "        \"URL\": \"https://archive.podaac.uat.earthdata.nasa.gov/s3credentials\",\n",
+      "        \"Type\": \"VIEW RELATED INFORMATION\",\n",
+      "        \"Description\": \"api endpoint to retrieve temporary credentials valid for same-region direct s3 access\"\n",
+      "      }\n",
+      "    ],\n",
+      "    \"SpatialExtent\": {\n",
+      "      \"HorizontalSpatialDomain\": {\n",
+      "        \"Geometry\": {\n",
+      "          \"BoundingRectangles\": [\n",
+      "            {\n",
+      "              \"WestBoundingCoordinate\": -150.336,\n",
+      "              \"EastBoundingCoordinate\": -110.883,\n",
+      "              \"NorthBoundingCoordinate\": 60.293,\n",
+      "              \"SouthBoundingCoordinate\": 38.478\n",
+      "            }\n",
+      "          ]\n",
+      "        }\n",
+      "      }\n",
+      "    },\n",
+      "    \"ProviderDates\": [\n",
+      "      {\n",
+      "        \"Date\": \"2020-08-10T14:44:40.727Z\",\n",
+      "        \"Type\": \"Insert\"\n",
+      "      },\n",
+      "      {\n",
+      "        \"Date\": \"2020-08-10T14:44:40.728Z\",\n",
+      "        \"Type\": \"Update\"\n",
+      "      }\n",
+      "    ],\n",
+      "    \"CollectionReference\": {\n",
+      "      \"ShortName\": \"MODIS_A-JPL-L2P-v2019.0\",\n",
+      "      \"Version\": \"2019.0\"\n",
+      "    },\n",
+      "    \"DataGranule\": {\n",
+      "      \"DayNightFlag\": \"Unspecified\",\n",
+      "      \"ProductionDateTime\": \"2020-08-10T14:42:14.000Z\",\n",
+      "      \"ArchiveAndDistributionInformation\": [\n",
+      "        {\n",
+      "          \"Name\": \"Not provided\",\n",
+      "          \"Size\": 22.679931640625,\n",
+      "          \"SizeUnit\": \"MB\"\n",
+      "        }\n",
+      "      ]\n",
+      "    },\n",
+      "    \"TemporalExtent\": {\n",
+      "      \"RangeDateTime\": {\n",
+      "        \"BeginningDateTime\": \"2020-08-10T11:05:01.000Z\",\n",
+      "        \"EndingDateTime\": \"2020-08-10T11:09:58.000Z\"\n",
+      "      }\n",
+      "    },\n",
+      "    \"GranuleUR\": \"20200810110501-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0\",\n",
+      "    \"MetadataSpecification\": {\n",
+      "      \"URL\": \"https://cdn.earthdata.nasa.gov/umm/granule/v1.6.1\",\n",
+      "      \"Name\": \"UMM-G\",\n",
+      "      \"Version\": \"1.6.1\"\n",
+      "    }\n",
+      "  }\n",
+      "}\n"
+     ]
+    }
+   ],
+   "source": [
+    "if len(results['items'])>0:\n",
+    "    print(dumps(results['items'][0], indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The link for http access denoted by `\"Type\": \"GET DATA\"` in the list of `RelatedUrls`.\n",
+    "\n",
+    "Grab the download URL, but do it in a way that'll work for search results returning any number of granule records:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-08-10T20:09:59.943535Z",
+     "start_time": "2020-08-10T20:09:59.939038Z"
+    },
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "['https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200810110501-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200810110001-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200810110001-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809231501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809213501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809133501-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809133501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809120001-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809115501-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809115501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808223001-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808205501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808143001-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808143001-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808125500-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808111500-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808111500-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200807232500-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200807215000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200807214500-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200807201000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170529231511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170529213511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170506231011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170506230511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170506213011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170502233510-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170502233010-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170403222511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170403204511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170403191011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170401224011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170401223511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170401210011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170315233510-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170315233010-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170315215510-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170223222011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170223221511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170223204011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217225511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217211511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217194011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217194011-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217145510-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217132010-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217131510-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217114010-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211233510-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211233510-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211233010-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211215511-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211215511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211215000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211201511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211135511-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211121511-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211103511-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170207222011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170207222011-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170207221511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc',\n",
+       " 'https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170207204011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc']"
+      ]
+     },
+     "execution_count": 13,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "downloads = [r['umm']['RelatedUrls'][0]['URL'] for r in results['items']]\n",
+    "downloads"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-07-25T12:03:56.780074Z",
+     "start_time": "2020-07-25T12:03:56.777273Z"
+    }
+   },
+   "source": [
+    "Finish by downloading the files to the data directory in a loop. Overwrite `.update` with a new timestamp on success."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-08-10T20:18:12.840943Z",
+     "start_time": "2020-08-10T20:09:59.945391Z"
+    },
+    "scrolled": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2020-08-10 16:10:13.365572] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200810110501-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:10:18.975776] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200810110001-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:10:31.304843] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200810110001-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:10:53.600871] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809231501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:10:57.873046] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809213501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:11:08.034197] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809133501-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:11:13.276993] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809133501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:11:23.881797] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809120001-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:11:28.736203] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809115501-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:11:39.485791] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200809115501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:11:54.069467] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808223001-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:12:04.598151] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808205501-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:12:09.996264] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808143001-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:12:19.912755] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808143001-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:12:24.800578] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808125500-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:12:34.344117] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808111500-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:12:38.639197] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200808111500-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:12:48.810996] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200807232500-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:12:53.882255] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200807215000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:13:00.002196] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200807214500-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:13:04.365358] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20200807201000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:13:16.629838] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170529231511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:13:21.321980] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170529213511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:13:31.527094] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170506231011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:13:36.265612] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170506230511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:13:41.916333] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170506213011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:13:46.281718] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170502233510-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:13:55.152083] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170502233010-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:13:59.405846] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170403222511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:14:05.009704] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170403204511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:14:10.770693] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170403191011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:14:15.003264] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170401224011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:14:25.534173] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170401223511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:14:29.895261] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170401210011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:14:41.572266] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170315233510-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:14:46.289246] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170315233010-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:14:52.116066] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170315215510-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:14:57.738353] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170223222011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:15:13.384346] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170223221511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:15:23.422584] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170223204011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:15:27.931576] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217225511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[2020-08-10 16:15:37.323237] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217211511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:15:42.016601] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217194011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:15:53.458549] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217194011-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:16:06.300466] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217145510-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:16:20.545108] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217132010-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:16:24.906572] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217131510-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:16:30.120924] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170217114010-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:16:35.055420] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211233510-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:16:46.486338] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211233510-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:16:51.774150] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211233010-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:16:59.050474] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211215511-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:17:05.286920] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211215511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:17:17.746501] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211215000-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:17:27.765510] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211201511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:17:32.327060] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211135511-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:17:40.928408] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211121511-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:17:45.611211] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170211103511-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:17:56.680623] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170207222011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:18:01.981545] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170207222011-JPL-L2P_GHRSST-SSTskin-MODIS_A-N-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:18:08.549494] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170207221511-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n",
+      "[2020-08-10 16:18:12.839515] SUCCESS: https://archive.podaac.uat.earthdata.nasa.gov/podaac-uat-cumulus-protected/MODIS_A-JPL-L2P-v2019.0/20170207204011-JPL-L2P_GHRSST-SSTskin-MODIS_A-D-v02.0-fv01.0.nc\n"
+     ]
+    }
+   ],
+   "source": [
+    "for f in downloads:\n",
+    "    try:\n",
+    "        urlretrieve(f, f\"{data}/{basename(f)}\")\n",
+    "    except Exception as e:\n",
+    "        print(f\"[{datetime.now()}] FAILURE: {f}\\n\\n{e}\\n\")\n",
+    "        raise e\n",
+    "    else:\n",
+    "        print(f\"[{datetime.now()}] SUCCESS: {f}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "If there were updates to the local time series during this run and no exceptions were raised during the download loop, then overwrite the timestamp file that tracks updates to the data folder (`resources/nrt/.update`):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2020-08-10T20:18:12.846894Z",
+     "start_time": "2020-08-10T20:18:12.842383Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "if len(results['items'])>0:\n",
+    "    with open(f\"{data}/.update\", \"w\") as f:\n",
+    "        f.write(timestamp)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.7"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": true,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": true,
+   "toc_position": {
+    "height": "calc(100% - 180px)",
+    "left": "10px",
+    "top": "150px",
+    "width": "241.528px"
+   },
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
this branch merges the current S6 NRT notebook (tracked by the develop branch) and adds a default download directory to the .gitignore file (notebooks/resources/nrt/)

develop is currently tracking 8 notebooks versus master's 5(+1)