### PR TITLE
Add source to quarto book and edit template

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -10,7 +10,7 @@ website:
   title: "PO.DAAC Cookbook" 
   site-url: "https://podaac.github.io/tutorials/" 
   repo-url: https://github.com/podaac/tutorials
-  repo-actions: [edit, issue]
+  repo-actions: [edit, source, issue]
   
   page-footer:
     right: "This page is built with [Quarto](https://quarto.org/)."

--- a/notebooks/Tutorials_TEMPLATE.ipynb
+++ b/notebooks/Tutorials_TEMPLATE.ipynb
@@ -4,13 +4,6 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "> From the PO.DAAC Cookbook, to access the GitHub version of the notebook, follow [this link](https://github.com/podaac/tutorials/blob/master/notebooks/Tutorials_TEMPLATE.ipynb). **Change this link to link to your tutorial.**"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
     "*Internal Note:* \n",
     "- *The following is a tutorial template to be used by PO.DAAC staff when developing end-user tutorials.*\n",
     "- *Copy this template and edit to create your notebook, keeping as many key elements as appropriate.*\n",
@@ -217,7 +210,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.12"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Add button below navbar so that a user can click to link to the github version of the source. Update the tutorials template to no longer have the tag at the top to link to the github source.