### PR TITLE
Update nd to tiff tutorial, add cloud callout to SWOT notebook

### DIFF
--- a/notebooks/GIS/Subscriber_nc_to_tif_SWOT.qmd
+++ b/notebooks/GIS/Subscriber_nc_to_tif_SWOT.qmd
@@ -40,6 +40,8 @@ Then, after [installing the podaac-data-subscriber package](https://github.com/p
 podaac-data-downloader -c SWOT_SIMULATED_NA_CONTINENT_L2_HR_RASTER_V1 -d ~/test_podaac/ -sd 2022-08-22T19:30:00Z -ed 2022-08-22T19:35:00Z --process "${PWD}/test.sh"
 ```
 
+If you get a permission denied error for test.sh, Make sure the permissions on the .sh file are set to read, write & executable. If you are unsure what your permissions are, in the command prompt you can execute "chmod 0755 test.sh" and permissions should be updated.
+
 **Listed Results from the above command should be as follows:**
 
 ```


### PR DESCRIPTION
Add in a couple sentences to the nc to tiff tutorial to give an explanation of a permissions warning. Make cloud callout more obvious in SWOT tutorial.