### PR TITLE
fix typo for link

### DIFF
--- a/quarto_text/Experimental.qmd
+++ b/quarto_text/Experimental.qmd
@@ -1,5 +1,8 @@
 ---
-title: In Development/Experimental
+title: In Development
+subtitle: Notebooks undergoing testing
 ---
 
-Content coming soon!
+#### [AWS Lambda Demonstration](../notebooks/aws_lambda_sst/podaac-lambda-invoke-sst-global-mean.ipynb) - Scale Scientific Analysis in the Cloud
+
+- This tutorial demonstrates how to plot a timeseries of global mean sea surface temperature values using AWS Lambda to perform the global mean computation using the MUR 25km dataset.


### PR DESCRIPTION
I forgot to add a slash in the link