### PR TITLE
Remove link to imported notebook

### DIFF
--- a/_import/assets.json
+++ b/_import/assets.json
@@ -24,14 +24,6 @@
         "process": true
     },
     {
-        "title": "Access Sample SWOT Oceanography Data in the Cloud",
-        "preamble": "This notebook is from a different repository in NASA's PO.DAAC, 2022-SWOT-OCEAN-Cloud-Workshop",
-        "source": "https://github.com/podaac/2022-SWOT-Ocean-Cloud-Workshop/blob/main/tutorials/01_Direct_Access_SWOT_sim.ipynb",
-        "url": "https://raw.githubusercontent.com/podaac/2022-SWOT-Ocean-Cloud-Workshop/main/tutorials/01_Direct_Access_SWOT_sim.ipynb",
-        "target": "Direct_Access_SWOT_sim_Oceanography.ipynb",
-        "process": true
-    },
-    {
         "title": "Xarray",
         "preamble": "This notebook is from NASA Openscapes 2021 Cloud Hackathon Repository",
         "source": "https://github.com/NASA-Openscapes/2021-Cloud-Hackathon/blob/main/tutorials/03_Xarray_hvplot.ipynb",

--- a/external/Direct_Access_SWOT_sim_Oceanography.ipynb
+++ b/external/Direct_Access_SWOT_sim_Oceanography.ipynb
@@ -6,11 +6,9 @@
    "source": [
     "# Access Sample SWOT Oceanography Data in the Cloud\n",
     "\n",
-    "imported on: **2023-03-02**\n",
+    "<p>This notebook is based on a tutorial given at the 2022 SWOT OCEAN Cloud Workshop</p>\n",
     "\n",
-    "<p>This notebook is from a different repository in NASA's PO.DAAC, 2022-SWOT-OCEAN-Cloud-Workshop</p>\n",
-    "\n",
-    "> The original source for this document is [https://github.com/podaac/2022-SWOT-Ocean-Cloud-Workshop/blob/main/tutorials/01_Direct_Access_SWOT_sim.ipynb](https://github.com/podaac/2022-SWOT-Ocean-Cloud-Workshop/blob/main/tutorials/01_Direct_Access_SWOT_sim.ipynb)"
+    "> The original source for the previous version of this document is [https://github.com/podaac/2022-SWOT-Ocean-Cloud-Workshop/blob/main/tutorials/01_Direct_Access_SWOT_sim.ipynb](https://github.com/podaac/2022-SWOT-Ocean-Cloud-Workshop/blob/main/tutorials/01_Direct_Access_SWOT_sim.ipynb)"
    ]
   },
   {
@@ -13358,7 +13356,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.16"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
The SWOT oceanography direct access notebook has been updated since the workshop was hosted to have earthaccess. We will keep the workshop tutorial as is and continue to update only the imported file in the external folder.