### PR TITLE
fix pngs for swot datetime notebook

### DIFF
--- a/notebooks/GIS/SWOT_datetime_GIS.ipynb
+++ b/notebooks/GIS/SWOT_datetime_GIS.ipynb
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -67,8 +67,7 @@
     "import matplotlib.pyplot as plt\n",
     "import contextily as cx\n",
     "import zipfile\n",
-    "import earthaccess\n",
-    "from earthaccess import Auth, DataCollections, DataGranules, Store"
+    "import earthaccess"
    ]
   },
   {
@@ -82,7 +81,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -100,9 +99,17 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Granules found: 192\n"
+     ]
+    }
+   ],
    "source": [
     "results = earthaccess.search_data(short_name = 'SWOT_L2_HR_RIVERSP_2.0', \n",
     "                                  temporal = ('2024-02-01 00:00:00', '2024-02-29 23:59:59'), # can also specify by time\n",
@@ -188,7 +195,7 @@
     "\n",
     "The ‘no_data’ values do not get converted; it keeps it as ‘NULL’\n",
     "\n",
-    "<nop/> <div style=\"width: 500px;\">![arcpro_datetime_1.png](../../images/swot_datetime/arcpro_datetime_1.png)</div>"
+    "<nop/> <div style=\"width: 500px;\">![arcpro_datetime_1.png](../../images/swot_datetime/arcpro_datetime_1.PNG)</div>"
    ]
   },
   {
@@ -201,9 +208,9 @@
     "\n",
     "In this case, we will configure a line plot in the chart properties of the median of water surface elevation 'wse'.\n",
     "\n",
-    "<nop/> <div style=\"width: 250px;\">![arcpro_datetime_2.png](../../images/swot_datetime/arcpro_datetime_2.png)</div>\n",
+    "<nop/> <div style=\"width: 250px;\">![arcpro_datetime_2.png](../../images/swot_datetime/arcpro_datetime_2.PNG)</div>\n",
     "\n",
-    "<nop/> <div style=\"width: 1100px;\">![arcpro_datetime_3.png](../../images/swot_datetime/arcpro_datetime_3.png)</div>"
+    "<nop/> <div style=\"width: 1100px;\">![arcpro_datetime_3.png](../../images/swot_datetime/arcpro_datetime_3.PNG)</div>"
    ]
   },
   {
@@ -218,7 +225,7 @@
     "\n",
     "In this case the date/time field 'time_str' can be changed to a date/time data type.\n",
     "\n",
-    "<nop/> <div style=\"width: 700px;\">![qgis_datetime_1.png](../../images/swot_datetime/qgis_datetime_1.png)</div>\n",
+    "<nop/> <div style=\"width: 700px;\">![qgis_datetime_1.png](../../images/swot_datetime/qgis_datetime_1.PNG)</div>\n",
     "\n",
     "In the 'type' section, you can select the data type of your choosing but for this case we will select 'Date & Time'.\n",
     "\n",
@@ -235,7 +242,7 @@
     "\n",
     "As shown in the image below; the black symbology is the original layer and the red symbology is the newly created layer without the 'no_data' values.\n",
     "\n",
-    "<nop/> <div style=\"width: 400px;\">![qgis_datetime_3.png](../../images/swot_datetime/qgis_datetime_3.png)</div>"
+    "<nop/> <div style=\"width: 400px;\">![qgis_datetime_3.png](../../images/swot_datetime/qgis_datetime_3.PNG)</div>"
    ]
   },
   {
@@ -257,7 +264,7 @@
     "\n",
     "For this example, we will configure a box plot looking at both time and 'wse'. Also, querying 'wse' to only include values greater than 0, so it does not include any negative values.\n",
     "\n",
-    "<nop/> <div style=\"width: 600px;\">![qgis_datetime_5.png](../../images/swot_datetime/qgis_datetime_5.png)</div>"
+    "<nop/> <div style=\"width: 600px;\">![qgis_datetime_5.png](../../images/swot_datetime/qgis_datetime_5.PNG)</div>"
    ]
   },
   {
@@ -266,7 +273,7 @@
    "source": [
     "This plot showcases the data without the date/time transformation for a single month.\n",
     "\n",
-    "<nop/> <div style=\"width: 700px;\">![qgis_datetime_6.png](../../images/swot_datetime/qgis_datetime_6.png)</div>\n",
+    "<nop/> <div style=\"width: 700px;\">![qgis_datetime_6.png](../../images/swot_datetime/qgis_datetime_6.PNG)</div>\n",
     "\n",
     "This plot is the same single month dataset but with the date/time transformation.\n",
     "\n",
@@ -294,7 +301,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.5"
+   "version": "3.8.13"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Some files are save as lowercase .png and some are saved as uppercase .PNG, and the cookbook is apparently case sensitive when rendering.