### PR TITLE
Update SIC4DVar FLPE discharge variable

### DIFF
--- a/notebooks/datasets/SWOT_L4_DAWG_SOS_DISCHARGE.ipynb
+++ b/notebooks/datasets/SWOT_L4_DAWG_SOS_DISCHARGE.ipynb
@@ -50,7 +50,7 @@
     "| MOMMA                            | Q                                | results[\"momma\"][\"Q\"]            |\n",
     "| neoBAM                           | q1, q2, or q3                    | results[\"neobam\"][\"q\"][\"q1\"]     |\n",
     "| SAD                              | Qa                               | results[\"sad\"][\"Qa\"]             |\n",
-    "| SIC4DVar                         | Q_mm                             | results[\"sic4dvar\"][\"Q_mm\"]      |\n",
+    "| SIC4DVar                         | Q_da                             | results[\"sic4dvar\"][\"Q_da\"]      |\n",
     "| MOI HiVDI                        | q                                | results[\"moi\"][\"hivdi\"][\"q\"]     |\n",
     "| MOI MetroMan                     | q                                | results[\"moi\"][\"metroman\"][\"q\"]  |\n",
     "| MOI MOMMA                        | q                                | results[\"moi\"][\"momma\"][\"q\"]     |\n",
@@ -1150,7 +1150,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/datasets/SWOT_L4_DAWG_SOS_DISCHARGE_gauges.ipynb
+++ b/notebooks/datasets/SWOT_L4_DAWG_SOS_DISCHARGE_gauges.ipynb
@@ -772,7 +772,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/datasets/SWOT_L4_DAWG_SOS_DISCHARGE_gauges_plot_all.ipynb
+++ b/notebooks/datasets/SWOT_L4_DAWG_SOS_DISCHARGE_gauges_plot_all.ipynb
@@ -602,7 +602,7 @@
     "print(f\"Number of SAD discharge values: {hivdi_q.shape[0]}\")\n",
     "\n",
     "# SIC4DVar\n",
-    "sic4dvar_q = get_algorithm_discharge(results, \"sic4dvar\", \"Q_mm\", reach_q_index, nonmissing_indexes, time.shape)\n",
+    "sic4dvar_q = get_algorithm_discharge(results, \"sic4dvar\", \"Q_da\", reach_q_index, nonmissing_indexes, time.shape)\n",
     "print(f\"Number of SIC4DVar discharge values: {hivdi_q.shape[0]}\")"
    ]
   },
@@ -977,7 +977,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,

--- a/notebooks/datasets/SWOT_L4_DAWG_SOS_DISCHARGE_visualize.ipynb
+++ b/notebooks/datasets/SWOT_L4_DAWG_SOS_DISCHARGE_visualize.ipynb
@@ -54,7 +54,7 @@
     "| MOMMA                            | Q                                | results[\"momma\"][\"Q\"]            |\n",
     "| neoBAM                           | q1, q2, or q3                    | results[\"neobam\"][\"q\"][\"q1\"]     |\n",
     "| SAD                              | Qa                               | results[\"sad\"][\"Qa\"]             |\n",
-    "| SIC4DVar                         | Q_mm                             | results[\"sic4dvar\"][\"Q_mm\"]      |\n",
+    "| SIC4DVar                         | Q_da                             | results[\"sic4dvar\"][\"Q_da\"]      |\n",
     "| MOI HiVDI                        | q                                | results[\"moi\"][\"hivdi\"][\"q\"]     |\n",
     "| MOI MetroMan                     | q                                | results[\"moi\"][\"metroman\"][\"q\"]  |\n",
     "| MOI MOMMA                        | q                                | results[\"moi\"][\"momma\"][\"q\"]     |\n",
@@ -1748,7 +1748,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.13"
+   "version": "3.12.3"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Updated notebooks to reference `Q_da` variable in SIC4DVAR discharge results.